### PR TITLE
vim: Remove the compilation timestamps

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -49,7 +49,7 @@ make_version()
     strcat(longVersion, ")");
 }
 # else
-char	*longVersion = VIM_VERSION_LONG_DATE __DATE__ " " __TIME__ ")";
+char	*longVersion = VIM_VERSION_LONG;
 # endif
 #else
 char	*longVersion = VIM_VERSION_LONG;


### PR DESCRIPTION
 * Storing the library compilation time for a specific log
    is not required and breaks the build

 * Fixes "expansion of date or time macro is not reproducible"

Change-Id: I53e4e8a48a2b732098e4e6d85c708abddb902341